### PR TITLE
:sparkles: Refactor BaseClient class and add cookie property accessor

### DIFF
--- a/simnet/client/base.py
+++ b/simnet/client/base.py
@@ -3,7 +3,7 @@ import uuid
 from types import TracebackType
 from typing import AsyncContextManager, Type, Optional, Any
 
-from httpx import AsyncClient as _AsyncClient, TimeoutException, Response, HTTPError, Timeout
+from httpx import AsyncClient, TimeoutException, Response, HTTPError, Timeout
 
 from simnet.client.cookies import Cookies
 from simnet.client.headers import Headers
@@ -22,33 +22,6 @@ from simnet.utils.types import (
 _LOGGER = logging.getLogger("SIMNet.BaseClient")
 
 __all__ = ("BaseClient",)
-
-
-class AsyncClient(_AsyncClient):
-    """This is the async client for httpx.AsyncClient clients."""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._cookies = Cookies(self._cookies)
-
-    def _merge_cookies(self, cookies: Optional[CookieTypes] = None) -> Optional[CookieTypes]:
-        """Merge a cookies argument together with any cookies on the client,
-        to create the cookies used for the outgoing request.
-        """
-        if cookies or self.cookies:
-            merged_cookies = Cookies(self.cookies)
-            merged_cookies.update(cookies)
-            return merged_cookies
-        return cookies
-
-    @property
-    def cookies(self) -> Cookies:
-        """Cookie values to include when sending requests."""
-        return self._cookies
-
-    @cookies.setter
-    def cookies(self, cookies: CookieTypes) -> None:
-        self._cookies = Cookies(cookies)
 
 
 class BaseClient(AsyncContextManager["BaseClient"]):
@@ -107,11 +80,10 @@ class BaseClient(AsyncContextManager["BaseClient"]):
     @property
     def cookies(self) -> Cookies:
         """Get the cookies used for the client."""
-        return self.client.cookies
+        return Cookies(self.client.cookies.jar)
 
     @cookies.setter
     def cookies(self, cookies: CookieTypes) -> None:
-        """Set the cookies to the client."""
         self.client.cookies = cookies
 
     @property

--- a/simnet/client/base.py
+++ b/simnet/client/base.py
@@ -43,9 +43,7 @@ class AsyncClient(_AsyncClient):
 
     @property
     def cookies(self) -> Cookies:
-        """
-        Cookie values to include when sending requests.
-        """
+        """Cookie values to include when sending requests."""
         return self._cookies
 
     @cookies.setter

--- a/simnet/client/base.py
+++ b/simnet/client/base.py
@@ -25,14 +25,13 @@ __all__ = ("BaseClient",)
 
 
 class AsyncClient(_AsyncClient):
-    """ This is the async client for httpx.AsyncClient clients."""
+    """This is the async client for httpx.AsyncClient clients."""
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._cookies = Cookies(self._cookies)
 
-    def _merge_cookies(
-        self, cookies: Optional[CookieTypes] = None
-    ) -> Optional[CookieTypes]:
+    def _merge_cookies(self, cookies: Optional[CookieTypes] = None) -> Optional[CookieTypes]:
         """Merge a cookies argument together with any cookies on the client,
         to create the cookies used for the outgoing request.
         """

--- a/simnet/client/cookies.py
+++ b/simnet/client/cookies.py
@@ -8,7 +8,7 @@ __all__ = ("Cookies",)
 class Cookies(_Cookies):
     """An extension of the `httpx.Cookies` class that includes additional functionality."""
 
-    COOKIE_USER_ID_NAMES = ("ltuid", "account_id", "ltuid_v2", "account_id_v2")
+    COOKIE_USER_ID_NAMES = ("ltuid", "account_id", "stuid", "ltuid_v2", "account_id_v2")
 
     @property
     def account_id(self) -> Optional[int]:

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -13,3 +13,5 @@ class TestBaseClient:
             client.cookies = {"account_id": "114514"}
             assert isinstance(client.cookies, Cookies)
             assert client.cookies.get("account_id") == "114514"
+            client.cookies.set("stuid", "114514")
+            assert client.cookies.get("stuid") == "114514"

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -6,7 +6,8 @@ from simnet.client.cookies import Cookies
 
 @pytest.mark.asyncio
 class TestBaseClient:
-    async def test_cookies(self):
+    @staticmethod
+    async def test_cookies():
         async with BaseClient(cookies={"uid": "114514"}) as client:
             assert isinstance(client.cookies, Cookies)
             client.cookies = {"account_id": "114514"}

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -1,0 +1,14 @@
+import pytest
+
+from simnet.client.base import BaseClient
+from simnet.client.cookies import Cookies
+
+
+@pytest.mark.asyncio
+class TestBaseClient:
+    async def test_cookies(self):
+        async with BaseClient(cookies={"uid": "114514"}) as client:
+            assert isinstance(client.cookies, Cookies)
+            client.cookies = {"account_id": "114514"}
+            assert isinstance(client.cookies, Cookies)
+            assert client.cookies.get("account_id") == "114514"


### PR DESCRIPTION
Added a `cookies` property accessor to the `BaseClient` class, which retrieves cookies from the `httpx` AsyncClient object and returns a `simnet.client.cookies.Cookies` object (which is a custom implementation of the `httpx.Cookies` class). Additionally, the initialization function was refactored to better support using cookies. Now, if `account_id` is not passed in, it will be retrieved from the cookies.