### PR TITLE
:white_check_mark: Add player ID check to client fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,31 +34,36 @@ def cookies() -> "Cookies":  # skipcq: PY-D0003
         pytest.exit("No cookies set", 1)
 
     _cookies = Cookies(parse_cookie(cookies_str))
+    if _cookies.account_id is None:
+        warnings.warn("can not found account id in cookies")
 
     return _cookies
 
 
 @pytest.fixture(scope="session")
-def genshin_player_id() -> int:  # skipcq: PY-D0003
+def genshin_player_id() -> Optional[int]:  # skipcq: PY-D0003
     _player_id = os.environ.get("GENSHIN_PLAYER_ID")
     if not _player_id:
-        pytest.exit("No genshin player id set", 1)
+        warnings.warn("No genshin player id set")
+        return None
     return int(_player_id)
 
 
 @pytest.fixture(scope="session")
-def starrail_player_id() -> int:  # skipcq: PY-D0003
+def starrail_player_id() -> Optional[int]:  # skipcq: PY-D0003
     _player_id = os.environ.get("STARRAIL_PLAYER_ID")
     if not _player_id:
-        pytest.exit("No genshin player id set", 1)
+        warnings.warn("No starrail player id set")
+        return None
     return int(_player_id)
 
 
 @pytest.fixture(scope="session")
-def account_id() -> int:  # skipcq: PY-D0003
+def account_id() -> Optional[int]:  # skipcq: PY-D0003
     _account_id = os.environ.get("ACCOUNT_ID")
     if not _account_id:
-        pytest.exit("No account id set", 1)
+        warnings.warn("No account id id set")
+        return None
     return int(_account_id)
 
 

--- a/tests/test_auth_client.py
+++ b/tests/test_auth_client.py
@@ -68,12 +68,12 @@ class TestAuthClient:
 
     @staticmethod
     async def test_get_authkey_by_stoken(stoken: str, account_id: int, region: "Region", genshin_player_id: int):
-        if auth_client.region != Region.CHINESE:
+        if region != Region.CHINESE:
             pytest.skip(
                 "Test case test_get_authkey_by_stoken skipped:This method is only available for the Chinese region."
             )
         if stoken is None:
-            pytest.skip("Test case test_get_authkey_by_stoken skipped: Parameter stoken  is None")
+            pytest.skip("Test case test_get_authkey_by_stoken skipped: Parameter stoken is None")
         async with AuthClient(
             cookies={"stoken": stoken},
             player_id=genshin_player_id,

--- a/tests/test_genshin.py
+++ b/tests/test_genshin.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 @pytest_asyncio.fixture
 async def genshin_client(genshin_player_id: int, account_id: int, region: "Region", cookies: "Cookies"):
+    if genshin_player_id is None:
+        pytest.skip("Test case test_genshin skipped: No starrail player id set.")
     async with GenshinClient(
         player_id=genshin_player_id,
         cookies=cookies,

--- a/tests/test_genshin_battle_chronicle_client.py
+++ b/tests/test_genshin_battle_chronicle_client.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 @pytest_asyncio.fixture
 async def genshin_client(genshin_player_id: int, account_id: int, region: "Region", cookies: "Cookies"):
+    if genshin_player_id is None:
+        pytest.skip("Test case test_genshin_battle_chronicle_client skipped: No starrail player id set.")
     async with GenshinBattleChronicleClient(
         player_id=genshin_player_id,
         cookies=cookies,

--- a/tests/test_genshin_calculator_client.py
+++ b/tests/test_genshin_calculator_client.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 @pytest_asyncio.fixture
 async def calculator_client(genshin_player_id: int, account_id: int, region: "Region", cookies: "Cookies"):
+    if genshin_player_id is None:
+        pytest.skip("Test case test_starrail_battle_chronicle_client skipped: No starrail player id set.")
     async with CalculatorClient(
         player_id=genshin_player_id,
         cookies=cookies,

--- a/tests/test_starrail.py
+++ b/tests/test_starrail.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 @pytest_asyncio.fixture
 async def starrail_client(starrail_player_id: int, account_id: int, region: "Region", cookies: "Cookies"):
+    if starrail_player_id is None:
+        pytest.skip("Test case test_starrail skipped: No starrail player id set.")
     async with StarRailClient(
         player_id=starrail_player_id,
         cookies=cookies,

--- a/tests/test_starrail_battle_chronicle_client.py
+++ b/tests/test_starrail_battle_chronicle_client.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 
 @pytest_asyncio.fixture
 async def starrail_client(starrail_player_id: int, account_id: int, region: "Region", cookies: "Cookies"):
+    if starrail_player_id is None:
+        pytest.skip("Test case test_genshin_calculator_client skipped: No starrail player id set.")
     async with StarRailBattleChronicleClient(
         player_id=starrail_player_id,
         cookies=cookies,


### PR DESCRIPTION
In various client fixtures, a player ID check has been added to ensure that the player ID parameter is not None before creating the client object. This check helps to handle scenarios where the player ID is not provided, preventing potential errors or undesired behavior.